### PR TITLE
Use MAXPLAYERS instead of MAX_PLAYERS in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Container Runtime Environment Variables:
 
 Example docker run:
 ```
-docker run --name "TF2-Server"		     \
-  -e APP_SERVER_PORT=27015      	     \
-  -e APP_SERVER_MAX_PLAYERS=24		     \
+docker run --name "TF2-Server"               \
+  -e APP_SERVER_PORT=27015                   \
+  -e APP_SERVER_MAXPLAYERS=24                \
   -e APP_SERVER_MAP=ctf_2fort                \
   -e APP_SERVER_TOKEN=abc123                 \
-  -e APP_SERVER_NAME="My TF2 Server"	     \
+  -e APP_SERVER_NAME="My TF2 Server"         \
   -e APP_SERVER_CONTACT="user@example.com"   \
   -e APP_SERVER_REGION=3                     \
   -e APP_RCON_PASSWORD=abc123                \


### PR DESCRIPTION
Many people (including myself) like to copy-paste examples in their console.
In my case, I wanted to set up an MvM server with a maximum of 32 players, so I changed the `24` to `32`, only to find out that this did not work, because the environment variable had one underscore too many :sweat_smile:  

I've also made the spacing in the example consistent; some lines had tabs, others didn't, so I removed the tabs :slightly_smiling_face: 